### PR TITLE
Update various typos and make minor improvements in the instructions

### DIFF
--- a/instructions/content/1-workflow/1-Overview/_index.en.md
+++ b/instructions/content/1-workflow/1-Overview/_index.en.md
@@ -9,7 +9,7 @@ In the coffee ordering application, each customer order follows a series of step
 
 * The initial QR code scan starts the ordering process.
 * The application checks that the shop is open and the barista's queue is not full. In this workshop, the barista can only handle up to 20 drinks at a time. If the shop is closed or the queue is full, the order process stops.
-* It waits 15 minutes for the customer to place the specifics of the drink order, such as a "Vanilla Latte with Soy Milk". If nothing happens after 15 minutes, the order times out.
+* It waits 5 minutes for the customer to place the specifics of the drink order, such as a "Vanilla Latte with Soy Milk". If nothing happens after 5 minutes, the order times out.
 * It waits 15 minutes for the barista to produce the drink. If nothing happens after 15 minutes, the order times out.
 * The order is finally completed or canceled by the barista.
 

--- a/instructions/content/1b-workflow/6-WaitForOrder/_index.en.md
+++ b/instructions/content/1b-workflow/6-WaitForOrder/_index.en.md
@@ -68,7 +68,7 @@ In this section, you add an EventBridge PutEvents state that emits an event when
 
 ![Drag UpdateItem to designer](../images/se-mod1-wait4.png)
 
-8. On the *Error handling tab*, for *Heartbeat*, enter `900` seconds. This means that the workflow will time out if the callback is not received within 15 minutes.
+8. On the *Error handling tab*, for *Heartbeat*, enter `300` seconds. This means that the workflow will time out if the callback is not received within 5 minutes.
 
 ![Configure heartbeat](../images/se-mod1-wait4c.png)
 

--- a/instructions/content/1b-workflow/7-Events/_index.en.md
+++ b/instructions/content/1b-workflow/7-Events/_index.en.md
@@ -61,7 +61,7 @@ In this section, you add an EventBridge PutEvents state that emits an event if e
 
 ## 2. Emitting an order finished event.
 
-In this section, you add an EventBridge PutEvents state that emits an event if the shop is closed or there is no capacity to accept new orders.
+In this section, you add an EventBridge PutEvents state that emits a final event when the order has finished, and the workflow has completed.
 
 ### Step-by-step instructions ##
 

--- a/instructions/content/2-events/7-testing-both-workflows/_index.en.md
+++ b/instructions/content/2-events/7-testing-both-workflows/_index.en.md
@@ -13,11 +13,12 @@ There are 3 steps:
 
 ### Setting up your browser tabs
 
-This section moves between different workflows and services. The prepare, open two tabs in your browser:
+This section moves between different workflows and services. The prepare, open multiple tabs in your browser:
 
 - In the first tab, go to the Step Functions console and open the *OrderProcessorWorkflow*. This is the workflow you built in module 1.
 - In the second tab, go to the Step Functions console and open the *OrderManagerStateMachine*. This workflow was deployed in the setup module.
-- Ensure you have the *EventBridge* Console  open in another tab.
+- Ensure you have the *EventBridge* Console open in another tab.
+- Finally, open the *DynamoDB* Console open in another tab.
 
 The instructions below will use all of these tabs, so leave these open for the duration of this section.
 

--- a/instructions/content/2-events/7-testing-both-workflows/_index.en.md
+++ b/instructions/content/2-events/7-testing-both-workflows/_index.en.md
@@ -13,7 +13,7 @@ There are 3 steps:
 
 ### Setting up your browser tabs
 
-This section moves between different workflows and services. The prepare, open multiple tabs in your browser:
+This section moves between different workflows and services. To prepare, open multiple tabs in your browser:
 
 - In the first tab, go to the Step Functions console and open the *OrderProcessorWorkflow*. This is the workflow you built in module 1.
 - In the second tab, go to the Step Functions console and open the *OrderManagerStateMachine*. This workflow was deployed in the setup module.

--- a/instructions/content/3-web-apps/3-frontends/1-displayapp/_index.en.md
+++ b/instructions/content/3-web-apps/3-frontends/1-displayapp/_index.en.md
@@ -27,7 +27,7 @@ Most of front end configurations have already been entered for you, you must loa
 
 2. From the List of Stacks, select the core stack it should be named something like **mod-67b03f2bcecc4faf**. 
 
-3.Cchoose the **Outputs** tab.
+3.Choose the **Outputs** tab.
 
 
 4. Find Output named *DisplayAppURI* and choose the pre created URL, Open this link in a new tab.
@@ -48,7 +48,7 @@ Most of front end configurations have already been entered for you, you must loa
 
 ## Setting up a user account
 
-The Serverlesspresso application supports bother user and admin accounts. The admin account can log into the Display and Barista apps, whereas users can only log into the Customer app. In this section, you will create an admin user to log into all apps.
+The Serverlesspresso application supports both user and admin accounts. The admin account can log into the Display and Barista apps, whereas users can only log into the Customer app. In this section, you will create an admin user to log into all apps.
 
 ### Step-by-step instructions ###
 

--- a/instructions/content/4-Advanced/order-processor-workflow/_index_en.md
+++ b/instructions/content/4-Advanced/order-processor-workflow/_index_en.md
@@ -28,13 +28,13 @@ aws stepfunctions start-execution --state-machine-arn YOUR_STATE_MACHINE_ARN --i
 
 ## 2. Testing timed out orders
 
-When you created the workflow, you added two transitions that wait for callbacks. These allow time for the customer to submit their order details, or the barista to make the drinks. The customer has 15 minutes to complete this step, and the barista has 15 minutes.
+When you created the workflow, you added two transitions that wait for callbacks. These allow time for the customer to submit their order details, or the barista to make the drinks. The customer has 5 minutes to complete this step, and the barista has 15 minutes.
 
 In this section, you will see what happens when a timeout occurs, using the executions you started in the previous step.
 
 ### Step-by-step instructions ##
 
-After 15 minutes have elapsed since you started the execution list, the executions that were running will terminate with a *Failed* state.  
+After 5 minutes have elapsed since you started the execution list, the executions that were running will terminate with a *Failed* state.  
 
 {{% notice info %}}
 Complete the following steps to see this for yourself, or move ahead to the [module review section](/1b-workflow/9-review.html).
@@ -45,7 +45,7 @@ Complete the following steps to see this for yourself, or move ahead to the [mod
 
 2. From the left-hand menu, select *State machine* and choose **OrderProcessorWorkflow** from the list.
 
-3. After 15 minutes have elapsed since you started the execution list. You will see that the executions that were running are now in a *Failed* state.
+3. After 5 minutes have elapsed since you started the execution list. You will see that the executions that were running are now in a *Failed* state.
 
 ![Timed out executions](/images/se-mod1-testing5.png)
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes multiple typos including those listed in #17 

*Description of changes:*
- The instructions switch between 5 minutes and 15 minutes for the customer order submission timeout. The app itself shows a 5 minute progress bar, therefore this update normalises the customer timeout to 5 minutes (300 seconds) in the instructions.
- The intro summary in `1b-workflow` step 2 incorrectly summarises step 3 instead. I have added a new summary for step 2.
- In `2 - end-to-end test` the instructions state to open 2 tabs, then specify 3 tabs to open. The user then also needs to go into DynamoDB, so I have updated the instructions to be more clear.
- Fix typos `Cchoose` -> `Choose` and `bother` -> `both`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
