### PR TITLE
Use $.cause content when customer timedout

### DIFF
--- a/instructions/content/1b-workflow/6-WaitForOrder/_index.en.md
+++ b/instructions/content/1b-workflow/6-WaitForOrder/_index.en.md
@@ -64,6 +64,7 @@ In this section, you add an EventBridge PutEvents state that emits an event when
 - For *Comment*, enter `Customer timed out`.
 - For *Errors*, select **States.Timeout**.
 - For *Fallback state*, select **Add new state**.
+- For *ResultPath*, enter `$.cause`.
 - Choose **Close**.
 
 ![Drag UpdateItem to designer](../images/se-mod1-wait4.png)


### PR DESCRIPTION
Closes: #15

* [x] Fix [instructions](/aws-samples/serverless-coffee-workshop/blob/main/instructions/content/1b-workflow/6-WaitForOrder/_index.en.md)
* [ ] Update [screenshot](/aws-samples/serverless-coffee-workshop/blob/main/instructions/static/images/se-mod1-wait4.png) (set ResultPath to `$.cause`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
