### PR TITLE
add mjs files to be processed by babel

### DIFF
--- a/frontends/vue-barista-app/vue.config.js
+++ b/frontends/vue-barista-app/vue.config.js
@@ -1,17 +1,29 @@
 module.exports = {
-  chainWebpack: config => {
+  configureWebpack: {
+    module: {
+      rules: [
+        {
+          test: /\.m?js$/,
+          use: {
+            loader: "babel-loader",
+          },
+        },
+      ],
+    },
+  },
+  chainWebpack: (config) => {
     config.module
-      .rule('vue')
-      .use('vue-loader')
-      .tap(options => {
+      .rule("vue")
+      .use("vue-loader")
+      .tap((options) => {
         options.compilerOptions = {
           ...(options.compilerOptions || {}),
-          isCustomElement: tag => tag.startsWith('amplify-')
+          isCustomElement: (tag) => tag.startsWith("amplify-"),
         };
         return options;
       });
   },
   devServer: {
-    host: 'localhost'
-  }
+    host: "localhost",
+  },
 };

--- a/frontends/vue-display-app/vue.config.js
+++ b/frontends/vue-display-app/vue.config.js
@@ -1,17 +1,29 @@
 module.exports = {
-  chainWebpack: config => {
+  configureWebpack: {
+    module: {
+      rules: [
+        {
+          test: /\.m?js$/,
+          use: {
+            loader: "babel-loader",
+          },
+        },
+      ],
+    },
+  },
+  chainWebpack: (config) => {
     config.module
-      .rule('vue')
-      .use('vue-loader')
-      .tap(options => {
+      .rule("vue")
+      .use("vue-loader")
+      .tap((options) => {
         options.compilerOptions = {
           ...(options.compilerOptions || {}),
-          isCustomElement: tag => tag.startsWith('amplify-')
+          isCustomElement: (tag) => tag.startsWith("amplify-"),
         };
         return options;
       });
   },
   devServer: {
-    host: 'localhost'
-  }
+    host: "localhost",
+  },
 };

--- a/frontends/vue-order-app/vue.config.js
+++ b/frontends/vue-order-app/vue.config.js
@@ -1,17 +1,29 @@
 module.exports = {
-  chainWebpack: config => {
+  configureWebpack: {
+    module: {
+      rules: [
+        {
+          test: /\.m?js$/,
+          use: {
+            loader: "babel-loader",
+          },
+        },
+      ],
+    },
+  },
+  chainWebpack: (config) => {
     config.module
-      .rule('vue')
-      .use('vue-loader')
-      .tap(options => {
+      .rule("vue")
+      .use("vue-loader")
+      .tap((options) => {
         options.compilerOptions = {
           ...(options.compilerOptions || {}),
-          isCustomElement: tag => tag.startsWith('amplify-')
+          isCustomElement: (tag) => tag.startsWith("amplify-"),
         };
         return options;
       });
   },
   devServer: {
-    host: 'localhost'
-  }
+    host: "localhost",
+  },
 };


### PR DESCRIPTION
Frontend projects cannot be build nor served because compiler throws errors:

```
Module parse failed: Unexpected token (xx:xx)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file.
```

Fixed by processing mjs files with babel.
