### PR TITLE
fix frontends by pinning vuestic-ui version

### DIFF
--- a/frontends/vue-barista-app/package.json
+++ b/frontends/vue-barista-app/package.json
@@ -17,7 +17,7 @@
     "mitt": "^3.0.0",
     "vue": "^3.0.0",
     "vue3-tel-input": "^1.0.4",
-    "vuestic-ui": "^1.1.1"
+    "vuestic-ui": "1.1.1"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.5.0",

--- a/frontends/vue-display-app/package.json
+++ b/frontends/vue-display-app/package.json
@@ -23,7 +23,7 @@
     "qrcode.vue": "^3.3.3",
     "vue": "^3.0.0",
     "vue3-tel-input": "^1.0.4",
-    "vuestic-ui": "^1.3.1"
+    "vuestic-ui": "1.3.1"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.5.15",

--- a/frontends/vue-order-app/package.json
+++ b/frontends/vue-order-app/package.json
@@ -23,7 +23,7 @@
     "vue-cli-plugin-vuestic-ui": "~1.0.1",
     "vue-router": "^4.0.12",
     "vue3-tel-input": "^1.0.4",
-    "vuestic-ui": "^1.1.1",
+    "vuestic-ui": "1.1.1",
     "vuex": "^4.0.2",
     "webpack": "^4.46.0"
   },


### PR DESCRIPTION
Currently the frontends cannot bei build due to an incompatible version of vuestic-ui.

vuestic-ui > 1.1 has some breaking changes, so we need to use exact versions to be able to build and run the frontends.
