### PR TITLE
fix: use ATS iot endpoint in GetIotEndpoint

### DIFF
--- a/backends/0-core/code/GetIoTEndpoint/GetIoTEndpoint.js
+++ b/backends/0-core/code/GetIoTEndpoint/GetIoTEndpoint.js
@@ -14,7 +14,7 @@ exports.handler = function (event, context) {
   }
 
   const iot = new aws.Iot()
-  iot.describeEndpoint({}, (err, data) => {
+  iot.describeEndpoint({ endpointType: "iot:Data-ATS" }, (err, data) => {
     let responseData, responseStatus
     if (err) {
       responseStatus = "FAILED"


### PR DESCRIPTION
Looks like this is already applied to the template file in s3 but not updated in the source code.

More info: https://github.com/aws/aws-iot-device-sdk-js/issues/240

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
