### PR TITLE
Remove redundant setting of client region

### DIFF
--- a/backends/11-order-metrics-cloudwatch/code/PublishMetrics.js
+++ b/backends/11-order-metrics-cloudwatch/code/PublishMetrics.js
@@ -1,8 +1,6 @@
 const { CloudWatch } = require('@aws-sdk/client-cloudwatch');
 
-const cloudWatch = new CloudWatch({
-  region: process.env.AWS_REGION
-})
+const cloudWatch = new CloudWatch()
 
 exports.handler = async (event) => {
   console.log(JSON.stringify(event, null, 2))

--- a/backends/2-config-service/code/configChanged.js
+++ b/backends/2-config-service/code/configChanged.js
@@ -9,9 +9,7 @@ const { DynamoDB } = require('@aws-sdk/client-dynamodb');
 const { EventBridge } = require('@aws-sdk/client-eventbridge');
 
 const documentClient = DynamoDBDocument.from(new DynamoDB())
-const eventbridge = new EventBridge({
-  region: process.env.AWS_REGION
-})
+const eventbridge = new EventBridge()
 
 // Returns application config
 exports.handler = async (event) => {

--- a/backends/3-capacity-service/code/isCapacityAvailable.js
+++ b/backends/3-capacity-service/code/isCapacityAvailable.js
@@ -4,9 +4,7 @@
 
 const { SFN } = require('@aws-sdk/client-sfn');
 
-const stepFunctions = new SFN({
-  region: process.env.AWS_REGION
-})
+const stepFunctions = new SFN()
 
 // Gets current number of running executions in state machine
 const getQueueSize = async (record) => {

--- a/backends/4-order-processing/functions/capacity/isCapacityAvailable.js
+++ b/backends/4-order-processing/functions/capacity/isCapacityAvailable.js
@@ -4,9 +4,7 @@
 
 const { SFN } = require('@aws-sdk/client-sfn');
 
-const stepFunctions = new SFN({
-  region: process.env.AWS_REGION
-})
+const stepFunctions = new SFN()
 
 // Gets current number of running executions in state machine
 const getQueueSize = async (record) => {

--- a/backends/5-order-manager/api/apiCancelOrder.js
+++ b/backends/5-order-manager/api/apiCancelOrder.js
@@ -10,12 +10,8 @@ const { EventBridge } = require('@aws-sdk/client-eventbridge');
 const { SFN } = require('@aws-sdk/client-sfn');
 
 const documentClient = DynamoDBDocument.from(new DynamoDB())
-const eventbridge = new EventBridge({
-  region: process.env.AWS_REGION,
-})
-const stepFunctions = new SFN({
-  region: process.env.AWS_REGION,
-})
+const eventbridge = new EventBridge()
+const stepFunctions = new SFN()
 
 const headers = {
   'Content-Type': 'application/json',

--- a/backends/5-order-manager/api/apiCompleteOrder.js
+++ b/backends/5-order-manager/api/apiCompleteOrder.js
@@ -10,12 +10,8 @@ const { EventBridge } = require('@aws-sdk/client-eventbridge');
 const { SFN } = require('@aws-sdk/client-sfn');
 
 const documentClient = DynamoDBDocument.from(new DynamoDB())
-const eventbridge = new EventBridge({
-  region: process.env.AWS_REGION,
-})
-const stepFunctions = new SFN({
-  region: process.env.AWS_REGION,
-})
+const eventbridge = new EventBridge()
+const stepFunctions = new SFN()
 
 const headers = {
   'Content-Type': 'application/json',

--- a/backends/5-order-manager/api/apiMakeOrder.js
+++ b/backends/5-order-manager/api/apiMakeOrder.js
@@ -9,9 +9,7 @@ const { DynamoDB } = require('@aws-sdk/client-dynamodb');
 const { EventBridge } = require('@aws-sdk/client-eventbridge');
 
 const documentClient = DynamoDBDocument.from(new DynamoDB())
-const eventbridge = new EventBridge({
-  region: process.env.AWS_REGION,
-})
+const eventbridge = new EventBridge()
 
 const isAdmin = (requestContext) => {
   try {

--- a/backends/5-order-manager/api/put.js
+++ b/backends/5-order-manager/api/put.js
@@ -8,9 +8,7 @@ const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
 const { DynamoDB } = require("@aws-sdk/client-dynamodb");
 const { SFN } = require("@aws-sdk/client-sfn");
 
-const stepFunctions = new SFN({
-  region: process.env.AWS_REGION,
-})
+const stepFunctions = new SFN()
 const documentClient = DynamoDBDocument.from(new DynamoDB())
 const axios = require('axios')
 

--- a/backends/5-order-manager/events/OrderProcessorOrderStarted.js
+++ b/backends/5-order-manager/events/OrderProcessorOrderStarted.js
@@ -9,9 +9,7 @@ const { DynamoDB } = require("@aws-sdk/client-dynamodb");
 const { SFN } = require("@aws-sdk/client-sfn");
 
 const documentClient = DynamoDBDocument.from(new DynamoDB())
-const stepFunctions = new SFN({
-  region: process.env.AWS_REGION,
-})
+const stepFunctions = new SFN()
 
 // Returns details of a Place ID where the app has user-generated content.
 exports.handler = async (event) => {

--- a/backends/5-order-manager/events/OrderProcessorWaitingCompletion.js
+++ b/backends/5-order-manager/events/OrderProcessorWaitingCompletion.js
@@ -9,9 +9,7 @@ const { DynamoDB } = require("@aws-sdk/client-dynamodb");
 const { EventBridge } = require("@aws-sdk/client-eventbridge");
 
 const documentClient = DynamoDBDocument.from(new DynamoDB())
-const eventbridge = new EventBridge({
-  region: process.env.AWS_REGION,
-})
+const eventbridge = new EventBridge()
 
 // Returns details of a Place ID where the app has user-generated content.
 exports.handler = async (event) => {

--- a/backends/5-order-manager/functions/getById/app.js
+++ b/backends/5-order-manager/functions/getById/app.js
@@ -8,9 +8,7 @@ const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
 const { DynamoDB } = require("@aws-sdk/client-dynamodb");
 const { SFN } = require("@aws-sdk/client-sfn");
 
-const stepFunctions = new SFN({
-  region: process.env.AWS_REGION,
-})
+const stepFunctions = new SFN()
 const documentClient = DynamoDBDocument.from(new DynamoDB())
 
 // Update order

--- a/backends/5-order-manager/functions/waitingCompletion/app.js
+++ b/backends/5-order-manager/functions/waitingCompletion/app.js
@@ -9,9 +9,7 @@ const { DynamoDB } = require("@aws-sdk/client-dynamodb");
 const { EventBridge } = require("@aws-sdk/client-eventbridge");
 
 const documentClient = DynamoDBDocument.from(new DynamoDB())
-const eventbridge = new EventBridge({
-  region: process.env.AWS_REGION,
-})
+const eventbridge = new EventBridge()
 
 // Returns details of a Place ID where the app has user-generated content.
 exports.handler = async (event) => {

--- a/backends/5-order-manager/robot/put.js
+++ b/backends/5-order-manager/robot/put.js
@@ -8,9 +8,7 @@ const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
 const { DynamoDB } = require("@aws-sdk/client-dynamodb");
 const { SFN } = require("@aws-sdk/client-sfn");
 
-const stepFunctions = new SFN({
-  region: process.env.AWS_REGION,
-})
+const stepFunctions = new SFN()
 const documentClient = DynamoDBDocument.from(new DynamoDB())
 const axios = require('axios')
 

--- a/backends/5-order-manager/robot/sendOrders.js
+++ b/backends/5-order-manager/robot/sendOrders.js
@@ -5,9 +5,7 @@
 'use strict';
 const { EventBridge } = require('@aws-sdk/client-eventbridge');
 
-const eventbridge = new EventBridge({
-  region: process.env.AWS_REGION
-})
+const eventbridge = new EventBridge()
 
 const { nanoid } = require('nanoid')
 const axios = require('axios')

--- a/backends/7-metrics-service/code/OrderManagerOrderCancelled.js
+++ b/backends/7-metrics-service/code/OrderManagerOrderCancelled.js
@@ -4,9 +4,7 @@
 
 const { CloudWatch } = require('@aws-sdk/client-cloudwatch');
 
-const cloudWatch = new CloudWatch({
-  region: process.env.AWS_REGION
-})
+const cloudWatch = new CloudWatch()
 
 exports.handler = async (event) => {
   console.log(JSON.stringify(event, null, 2))

--- a/backends/7-metrics-service/code/OrderManagerWaitingCompletion.js
+++ b/backends/7-metrics-service/code/OrderManagerWaitingCompletion.js
@@ -2,9 +2,7 @@
  *  SPDX-License-Identifier: MIT-0
  */
 const { CloudWatch } = require('@aws-sdk/client-cloudwatch');
-const cloudWatch = new CloudWatch({
-  region: process.env.AWS_REGION
-})
+const cloudWatch = new CloudWatch()
 
 exports.handler = async (event) => {
   console.log(JSON.stringify(event, null, 2))

--- a/backends/7-metrics-service/code/OrderProcessorOrderTimeOut.js
+++ b/backends/7-metrics-service/code/OrderProcessorOrderTimeOut.js
@@ -4,9 +4,7 @@
 
 const { CloudWatch } = require('@aws-sdk/client-cloudwatch');
 
-const cloudWatch = new CloudWatch({
-  region: process.env.AWS_REGION
-})
+const cloudWatch = new CloudWatch()
 
 exports.handler = async (event) => {
   console.log(JSON.stringify(event, null, 2))

--- a/backends/7-metrics-service/code/ValidatorNewOrder.js
+++ b/backends/7-metrics-service/code/ValidatorNewOrder.js
@@ -3,9 +3,7 @@
  */
 
 const { CloudWatch } = require('@aws-sdk/client-cloudwatch');
-const cloudWatch = new CloudWatch({
-  region: process.env.AWS_REGION
-})
+const cloudWatch = new CloudWatch()
 
 exports.handler = async (event) => {
   console.log(JSON.stringify(event, null, 2))

--- a/backends/9-validator/code/verifyCode.js
+++ b/backends/9-validator/code/verifyCode.js
@@ -4,9 +4,7 @@
 
 const { EventBridge } = require('@aws-sdk/client-eventbridge');
 
-const eventbridge = new EventBridge({
-  region: process.env.AWS_REGION,
-})
+const eventbridge = new EventBridge()
 
 const { nanoid } = require('nanoid')
 const { getItem, decrementToken } = require('./ddb')


### PR DESCRIPTION
*Issue #, if available:*
Noticed while reviewing https://github.com/aws-samples/serverless-coffee-workshop/pull/63

*Description of changes:*
The client region is not required to be set explicitly in JS SDK v3. It's automatically read from `AWS_REGION`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
