### PR TITLE
Remove identifier for DynamoDB import

### DIFF
--- a/backends/10-order-metrics-dynamodb/code/PublishMetrics.js
+++ b/backends/10-order-metrics-dynamodb/code/PublishMetrics.js
@@ -1,9 +1,7 @@
 const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
-const {
-    DynamoDB: dynamodb,
-} = require("@aws-sdk/client-dynamodb");
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
 
-const docClient = DynamoDBDocument.from(new dynamodb());
+const docClient = DynamoDBDocument.from(new DynamoDB());
 exports.handler = async (event) => {
     console.log(event)
     const date = new Date().toISOString().slice(0, 10);


### PR DESCRIPTION
*Issue #, if available:*
Noticed while reviewing https://github.com/aws-samples/serverless-coffee-workshop/pull/63

*Description of changes:*
Removes identifier added by codemod, as it was used by JS SDK v2 APIs. The original key can be used from import.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
